### PR TITLE
B32G20-142 US08 As a POS & sales manager, I should be able to access the Repairs page automation

### DIFF
--- a/src/test/java/com/twiliaerp/page/BasePage_US01_Buse.java
+++ b/src/test/java/com/twiliaerp/page/BasePage_US01_Buse.java
@@ -40,7 +40,7 @@ public abstract class BasePage_US01_Buse {
     @FindBy(xpath = "")
     public WebElement notesBtn;
 
-    @FindBy(xpath = "(")
+    @FindBy(xpath = "")
     public WebElement contactsBtn;
 
     @FindBy(xpath = "")
@@ -48,6 +48,9 @@ public abstract class BasePage_US01_Buse {
 
     @FindBy(css = "a[href='/web#menu_id=445&action=']")
     public WebElement salesBtn;
+
+    @FindBy(xpath = "//a[@href='/web#menu_id=535&action=723']")
+    public WebElement repairsBtn;
 
     public void loginWithExcelFileCredentials(String sheetName, int rowNum){
         ExcelUtil excelUtil = new ExcelUtil("src/testData/loginCredentials.xlsx",sheetName);

--- a/src/test/java/com/twiliaerp/page/RepairsPage_B32G20_141_Buse.java
+++ b/src/test/java/com/twiliaerp/page/RepairsPage_B32G20_141_Buse.java
@@ -1,0 +1,46 @@
+package com.twiliaerp.page;
+
+import com.twiliaerp.utilities.Driver;
+import io.cucumber.java.bs.A;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RepairsPage_B32G20_141_Buse extends BasePage_US01_Buse{
+
+    public RepairsPage_B32G20_141_Buse(){
+        PageFactory.initElements(Driver.getDriver(), this);
+    }
+
+    @FindBy(css = "th.o_column_sortable")
+    public List<WebElement> listTitles;
+
+    @FindBy(css = "input.o_searchview_input")
+    public WebElement searchBox;
+
+    @FindBy(css = "tr.o_data_row>td.o_data_cell")
+    public List<WebElement> searchResultElements;
+
+    @FindBy(xpath = "//th[text()='Repair Reference']")
+    public WebElement repairReferenceBtn;
+
+    public List<String> titlesList(){
+        List<String> list = new ArrayList<>();
+        for (WebElement each : listTitles){
+            list.add(each.getText());
+        }
+        return list;
+    }
+
+    public List<String> searchResultElements(){
+        List<String> list = new ArrayList<>();
+        for (WebElement each : searchResultElements){
+            list.add(each.getText());
+        }
+        return list;
+    }
+
+}

--- a/src/test/java/com/twiliaerp/step_definitions/RepairsPage_StepDef_B32G20_142_Buse.java
+++ b/src/test/java/com/twiliaerp/step_definitions/RepairsPage_StepDef_B32G20_142_Buse.java
@@ -1,0 +1,52 @@
+package com.twiliaerp.step_definitions;
+
+import com.twiliaerp.page.RepairsPage_B32G20_141_Buse;
+import com.twiliaerp.utilities.Driver;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.junit.Assert;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class RepairsPage_StepDef_B32G20_142_Buse {
+
+    RepairsPage_B32G20_141_Buse repairsPage = new RepairsPage_B32G20_141_Buse();
+    WebDriverWait wait = new WebDriverWait(Driver.getDriver(), Duration.ofSeconds(20));
+
+    @When("user clicks Repairs title and land on the page successfully")
+    public void user_clicks_repairs_title_and_land_on_the_page_successfully() {
+        repairsPage.repairsBtn.click();
+        wait.until(ExpectedConditions.visibilityOf(repairsPage.repairReferenceBtn));
+    }
+
+
+    @Then("user verify there are these columns to show the detail of the repair orders on the page")
+    public void user_verify_there_are_these_columns_to_show_the_detail_of_the_repair_orders_on_the_page(List<String> expectedList) {
+        Assert.assertEquals("Titles verification FAILED", expectedList, repairsPage.titlesList());
+    }
+
+    @When("user enters {string} in the search box on the Repairs page and hit the enter key")
+    public void user_enters_in_the_search_box_on_the_repairs_page_and_hit_the_enter_key(String string) throws InterruptedException {
+        repairsPage.searchBox.sendKeys(string + Keys.ENTER);
+        Thread.sleep(3000);
+
+
+    }
+
+    @Then("user should see the result on the Repair Order list : {string},{string},{string},{string},{string},{string}")
+    public void user_should_see_the_result_on_the_repair_order_list(String string, String string2, String string3, String string4, String string5, String string6) {
+        List<String> expectedList = new ArrayList<>(Arrays.asList(string,string2,string3,string4,string5,string6));
+        Assert.assertEquals(expectedList, repairsPage.searchResultElements());
+
+    }
+
+
+
+}

--- a/src/test/resources/features/RepairsPage_B32G20_142_Buse.feature
+++ b/src/test/resources/features/RepairsPage_B32G20_142_Buse.feature
@@ -1,0 +1,46 @@
+@B32G20-165
+Feature: Default
+
+	#*{color:#DE350B}*US08 *{color}*
+	#As a POS & sales manager, I should be able to access the Repairs page.
+	#*{color:#DE350B}*  Acceptance Criteria:*{color}*
+	#  +1. Verify there are 6 columns to show the details of the repair orders on the Repairs page when the POS & Sales Managers login.+
+	#  2. Verify user can see the result on the list when searching with Repair Reference data.
+  @B32G20-163
+  Scenario Outline: AC1:Verify there are 6 columns to show the details of the repair orders on the Repairs page when
+    Given user login successfully with valid credentials "<sheetName>", <rowNum>
+    When user clicks Repairs title and land on the page successfully
+    Then user verify there are these columns to show the detail of the repair orders on the page
+      | Repair Reference    |
+      | Product to Repair   |
+      | Customer            |
+      | Delivery Address    |
+      | Warranty Expiration |
+      | Status              |
+
+
+    Examples:
+      | sheetName    | rowNum |
+      | posmanager   | 5      |
+      | posmanager   | 55     |
+      | salesmanager | 2      |
+      | salesmanager | 65     |
+
+	#*{color:#DE350B} US08 {color}*
+	#As a POS & sales manager, I should be able to access the Repairs page.
+	#*{color:#DE350B}* {color:#DE350B}* Acceptance Criteria:*{color}*{color}*
+	#  1. Verify there are 6 columns to show the details of the repair orders on the Repairs page when the POS & Sales Managers login.
+	#  +2. Verify user can see the result on the list when searching with Repair Reference data.+
+  @B32G20-164
+  Scenario Outline: AC2: Verify user can see the result on the list when searching with Repair Reference data.
+    Given user login successfully with valid credentials "<sheetName>", <rowNum>
+    When user clicks Repairs title and land on the page successfully
+    When user enters "<searchRepairReference>" in the search box on the Repairs page and hit the enter key
+    Then user should see the result on the Repair Order list : "<eRepairReference>","<eProductToRepair>","<eCustomer>","<eDeliveryAddress>","<eWarrantyExpiration>","<eStatus>"
+
+    Examples:
+      | sheetName    | rowNum | searchRepairReference | eRepairReference | eProductToRepair | eCustomer             | eDeliveryAddress        | eWarrantyExpiration | eStatus         |
+      | posmanager   | 5      | RN                    | RN               | iPhone X         | ASUSTeK, James Miller | ASUSTeK, Peter Mitchell |                     | Ready to Repair |
+      | posmanager   | 55     | RMA/00302             | RMA/00302        | iPhone X         |                       |                         |                     | Confirmed       |
+      | salesmanager | 2      | RN                    | RN               | iPhone X         | ASUSTeK, James Miller | ASUSTeK, Peter Mitchell |                     | Ready to Repair |
+      | salesmanager | 65     | RMA/00302             | RMA/00302        | iPhone X         |                       |                         |                     | Confirmed       |


### PR DESCRIPTION
US08 
	#As a POS & sales manager, I should be able to access the Repairs page.
Acceptance Criteria:
	 1. Verify there are 6 columns to show the details of the repair orders on the Repairs page when the POS & Sales Managers login.
	2. Verify user can see the result on the list when searching with Repair Reference data.